### PR TITLE
fix(security): abort WebView load on SSL certificate errors (CWE-295)

### DIFF
--- a/app/src/main/java/com/bkash/rnd/pgwwebview/activity/WebViewCheckoutActivity.java
+++ b/app/src/main/java/com/bkash/rnd/pgwwebview/activity/WebViewCheckoutActivity.java
@@ -73,7 +73,11 @@ public class WebViewCheckoutActivity extends AppCompatActivity {
     private class CheckoutWebViewClient extends WebViewClient {
 
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-            handler.proceed();
+            // CWE-295: do NOT proceed on invalid certificates. This is a
+            // payment WebView; silently trusting any cert (or even
+            // prompting the user) lets a network attacker MITM the bKash
+            // checkout flow. Abort the request instead.
+            handler.cancel();
         }
 
         @Override


### PR DESCRIPTION
## Security fix - issue #6 (CWE-295)

Resolves #6

### Root cause

`CheckoutWebViewClient.onReceivedSslError` unconditionally calls
`handler.proceed()`:

```java
public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
    handler.proceed();
}
```

That tells the WebView to trust **any** certificate the server
presents - expired, self-signed, hostname-mismatched, or attacker-
issued. Because this Activity loads the bKash checkout flow, a network
attacker on the same Wi-Fi (coffee shop, hotel, hostile ISP) can MITM
the TLS connection and read or rewrite the payment request and
response. Google Play also flags this exact pattern and will warn /
block release uploads.

### What this PR changes

One file, `app/src/main/java/com/bkash/rnd/pgwwebview/activity/WebViewCheckoutActivity.java`:

- `onReceivedSslError` now calls `handler.cancel()` instead of
  `handler.proceed()`, so the request is aborted whenever the
  certificate fails the platform's validation.

### Why not show an "ignore?" dialog (the snippet from the issue)

The original issue suggests an `AlertDialog` asking the user whether
to continue. That is **not** appropriate for a payment screen: a
non-technical bKash customer faced with "Continue anyway?" will tap
yes, defeating the protection. The correct behaviour is to fail
closed; users in a broken-clock or corporate-MITM environment will
see the connection fail and can take it up with their network admin.

### Scope

Only the SSL handler is touched. Existing JS interface, navigation
handling, and progress-bar logic are unchanged.
