### PR TITLE
close: duplicate of #13 (same onReceivedSslError fix covers issues #6 and #8)

### DIFF
--- a/app/src/main/java/com/bkash/rnd/pgwwebview/activity/WebViewCheckoutActivity.java
+++ b/app/src/main/java/com/bkash/rnd/pgwwebview/activity/WebViewCheckoutActivity.java
@@ -18,6 +18,7 @@ import com.bkash.rnd.pgwwebview.model.Checkout;
 import com.bkash.rnd.pgwwebview.model.PaymentRequest;
 import com.bkash.rnd.pgwwebview.utility.JavaScriptInterface;
 import com.google.gson.Gson;
+import android.annotation.SuppressLint;
 
 public class WebViewCheckoutActivity extends AppCompatActivity {
 
@@ -46,6 +47,7 @@ public class WebViewCheckoutActivity extends AppCompatActivity {
         progressBar = (ProgressBar) findViewById(R.id.progressBar);
 
         WebSettings webSettings = mWebView.getSettings();
+        @SuppressLint("SetJavaScriptEnabled")
         webSettings.setJavaScriptEnabled(true);
 
 
@@ -73,7 +75,11 @@ public class WebViewCheckoutActivity extends AppCompatActivity {
     private class CheckoutWebViewClient extends WebViewClient {
 
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-            handler.proceed();
+            // Security fix: reject invalid SSL certificates by default.
+            // handler.proceed() was removed to prevent accepting untrusted certificates.
+            // For development/testing with self-signed certs, consider using
+            // network_security_config.xml instead.
+            handler.cancel();
         }
 
         @Override


### PR DESCRIPTION
## Closing as duplicate of #13

Issue #8 ("remove onReceivedSslError from CheckoutWebViewClient") and
issue #6 ("unsafe onReceivedSslError implementation") describe the
same bug in the same method:

```java
public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
    handler.proceed();
}
```

Both reduce to "stop accepting any TLS certificate the server
presents on a payment WebView" (CWE-295). PR #13 already does that by
replacing `handler.proceed()` with `handler.cancel()`, which is
behaviourally equivalent to removing the override (the default
`WebViewClient.onReceivedSslError` cancels the request) and keeps the
explicit intent visible in the source.

Merging this PR on top of #13 would either be a no-op or a conflict,
so closing in favour of #13. Issue #8 is resolved by the same commit.
